### PR TITLE
xhtml features for AppIndex, hreflang etc.

### DIFF
--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -109,4 +109,40 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($exceptionCaught, 'Expected InvalidArgumentException wasn\'t thrown.');
     }
+
+    public function testArrayOfLocations()
+    {
+        $fileName = __DIR__ . '/sitemap.xml';
+
+        $sitemap = new Sitemap($fileName);
+
+        // enable xhtml
+        $sitemap->setXhtml(true);
+
+        $sitemap
+        ->addItem(array(
+            'loc'  => 'http://www.example.com.ua/example/gizmos',
+            'ru' => array(
+                'href' => 'http://www.example.ru/example/gizmos',
+                'rel'  => 'alternate',
+                'hreflang' => 'ru',
+            ),
+            'ua' => array(
+                'href' => 'http://www.example.com.ua/example/gizmos',
+                'rel'  => 'alternate',
+                'hreflang' => 'ua',
+            ),
+            'android' => array(
+                'href' => 'android-app://com.example.android/example/gizmos',
+                'rel'  => 'alternate',
+            ),
+        ));
+
+        $sitemap->write();
+
+        $this->assertTrue(file_exists($fileName));
+        // $this->assertIsValidSitemap($fileName);
+
+        unlink($fileName);
+    }
 }


### PR DESCRIPTION
proposal: provide the ability to create AppIndex links and rel="alternate" links in addItem.

We need create sitemaps like:
```
<?xml version="1.0" encoding="UTF-8" ?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
 xmlns:xhtml="http://www.w3.org/1999/xhtml">
<url>
  <loc>http://example.com/gizmos</loc>
  <xhtml:link rel="alternate" href="android-app://com.example.android/example/gizmos" />
</url>
...
</urlset>
```
but current version not able to do that.

More about DeepLinkink, hreflang, AppIndex:
+ https://developers.google.com/app-indexing/webmasters/server
+ https://support.google.com/webmasters/answer/2620865?hl=ru