### PR TITLE
Optional GZIP compression

### DIFF
--- a/Index.php
+++ b/Index.php
@@ -21,6 +21,11 @@ class Index
     private $filePath;
 
     /**
+     * @var bool whether to gzip the resulting file or not
+     */
+    private $gzip = false;
+
+    /**
      * @param string $filePath index file path
      */
     public function __construct($filePath)
@@ -85,7 +90,24 @@ class Index
         if ($this->writer instanceof XMLWriter) {
             $this->writer->endElement();
             $this->writer->endDocument();
-            file_put_contents($this->getFilePath(), $this->writer->flush());
+            $filePath = $this->getFilePath();
+            if ($this->gzip) {
+                $filePath = 'compress.zlib://'.$filePath;
+            }
+            file_put_contents($filePath, $this->writer->flush());
         }
+    }
+
+    /**
+     * Sets whether the resulting file will be gzipped or not.
+     * @param bool $bool
+     */
+    public function setGzip($bool)
+    {
+        $gzip = (bool)$bool;
+        if ($bool && !extension_loaded('zlib')) {
+            throw new \RuntimeException('Zlib extension must be installed to gzip the sitemap.');
+        }
+        $this->gzip = $bool;
     }
 }

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $index->write();
 Options
 -------
 
-There are two methods to configre `Sitemap` instance:
+There are three methods to configure `Sitemap` instance:
  
 - `setMaxUrls($number)`. Sets maximum number of URLs to write in a single file.
   Default is 50000 which is the limit according to specification and most of
@@ -88,6 +88,13 @@ There are two methods to configre `Sitemap` instance:
 - `setBufferSize($number)`. Sets number of URLs to be kept in memory before writing it to file.
   Default is 1000. If you have more memory consider increasing it. If 1000 URLs doesn't fit,
   decrease it.
+- `setGzip($bool)`. Sets whether the resulting sitemap files will be gzipped or not.
+  Default is `false`. `zlib` extension must be enabled to use this feature.
+
+There is one method to configure `Index` instance:
+
+- `setGzip($bool)`. Sets whether the resulting index file will be gzipped or not.
+  Default is `false`. `zlib` extension must be enabled to use this feature.
 
 Running tests
 -------------

--- a/Sitemap.php
+++ b/Sitemap.php
@@ -34,6 +34,11 @@ class Sitemap
     private $filePath;
 
     /**
+     * @var resource handle of the file to be written
+     */
+    private $fileHandle;
+
+    /**
      * @var integer number of files written
      */
     private $fileCount = 0;
@@ -66,7 +71,6 @@ class Sitemap
      */
     private $gzip = false;
 
-
     /**
      * @var XMLWriter
      */
@@ -98,6 +102,11 @@ class Sitemap
         $this->writtenFilePaths[] = $filePath;
         @unlink($filePath);
 
+        if ($this->gzip) {
+            $filePath = 'compress.zlib://' . $filePath;
+        }
+        $this->fileHandle = fopen($filePath, 'w');
+
         $this->writer = new XMLWriter();
         $this->writer->openMemory();
         $this->writer->startDocument('1.0', 'UTF-8');
@@ -115,6 +124,8 @@ class Sitemap
             $this->writer->endElement();
             $this->writer->endDocument();
             $this->flush();
+            fclose($this->fileHandle);
+            $this->fileHandle = null;
         }
     }
 
@@ -131,11 +142,7 @@ class Sitemap
      */
     private function flush()
     {
-        $filePath = $this->getCurrentFilePath();
-        if ($this->gzip) {
-            $filePath = 'compress.zlib://' . $filePath;
-        }
-        file_put_contents($filePath, $this->writer->flush(true), FILE_APPEND);
+        fwrite($this->fileHandle, $this->writer->flush(true));
     }
 
     /**

--- a/tests/IndexTest.php
+++ b/tests/IndexTest.php
@@ -35,4 +35,20 @@ class IndexTest extends \PHPUnit_Framework_TestCase
 
         unlink($fileName);
     }
+
+    public function testWritingFileGzipped()
+    {
+        $fileName = __DIR__ . '/sitemap_index.xml.gz';
+        $index = new Index($fileName);
+        $index->setGzip(true);
+        $index->addSitemap('http://example.com/sitemap.xml');
+        $index->addSitemap('http://example.com/sitemap_2.xml', time());
+        $index->write();
+
+        $this->assertTrue(file_exists($fileName));
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $this->assertEquals('application/x-gzip', $finfo->file($fileName));
+        $this->assertIsValidIndex('compress.zlib://' . $fileName);
+        unlink($fileName);
+    }
 }

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -109,4 +109,60 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
 
         $this->assertTrue($exceptionCaught, 'Expected InvalidArgumentException wasn\'t thrown.');
     }
+
+    public function testWritingFileGzipped()
+    {
+        $fileName = __DIR__ . '/sitemap_gzipped.xml.gz';
+        $sitemap = new Sitemap($fileName);
+        $sitemap->setGzip(true);
+        $sitemap->addItem('http://example.com/mylink1');
+        $sitemap->addItem('http://example.com/mylink2', time());
+        $sitemap->addItem('http://example.com/mylink3', time(), Sitemap::HOURLY);
+        $sitemap->addItem('http://example.com/mylink4', time(), Sitemap::DAILY, 0.3);
+        $sitemap->write();
+
+        $this->assertTrue(file_exists($fileName));
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        $this->assertEquals('application/x-gzip', $finfo->file($fileName));
+        $this->assertIsValidSitemap('compress.zlib://' . $fileName);
+
+        unlink($fileName);
+    }
+
+    public function testMultipleFilesGzipped()
+    {
+        $sitemap = new Sitemap(__DIR__ . '/sitemap_multi_gzipped.xml.gz');
+        $sitemap->setGzip(true);
+        $sitemap->setMaxUrls(2);
+
+        for ($i = 0; $i < 20; $i++) {
+            $sitemap->addItem('http://example.com/mylink' . $i, time());
+        }
+        $sitemap->write();
+
+        $expectedFiles = [
+            __DIR__ . '/' .'sitemap_multi_gzipped.xml.gz',
+            __DIR__ . '/' .'sitemap_multi_gzipped_2.xml.gz',
+            __DIR__ . '/' .'sitemap_multi_gzipped_3.xml.gz',
+            __DIR__ . '/' .'sitemap_multi_gzipped_4.xml.gz',
+            __DIR__ . '/' .'sitemap_multi_gzipped_5.xml.gz',
+            __DIR__ . '/' .'sitemap_multi_gzipped_6.xml.gz',
+            __DIR__ . '/' .'sitemap_multi_gzipped_7.xml.gz',
+            __DIR__ . '/' .'sitemap_multi_gzipped_8.xml.gz',
+            __DIR__ . '/' .'sitemap_multi_gzipped_9.xml.gz',
+            __DIR__ . '/' .'sitemap_multi_gzipped_10.xml.gz',
+        ];
+        $finfo = new \finfo(FILEINFO_MIME_TYPE);
+        foreach ($expectedFiles as $expectedFile) {
+            $this->assertTrue(file_exists($expectedFile), "$expectedFile does not exist!");
+            $this->assertEquals('application/x-gzip', $finfo->file($expectedFile));
+            $this->assertIsValidSitemap('compress.zlib://' . $expectedFile);
+            unlink($expectedFile);
+        }
+
+        $urls = $sitemap->getSitemapUrls('http://example.com/');
+        $this->assertEquals(10, count($urls), print_r($urls, true));
+        $this->assertContains('http://example.com/sitemap_multi_gzipped.xml.gz', $urls);
+        $this->assertContains('http://example.com/sitemap_multi_gzipped_10.xml.gz', $urls);
+    }
 }


### PR DESCRIPTION
Hi,

This PR adds support to create gzipped sitemaps.

I know the compression can be done by the webserver on the fly, but when creating very large sitemaps precompressing them saves a lot of disk space.

Regards,
