### PR TITLE
Fix wrong phpdoc for parameter $changeFrequency

### DIFF
--- a/Sitemap.php
+++ b/Sitemap.php
@@ -255,7 +255,7 @@ class Sitemap
      *
      * @param string|array $location location item URL
      * @param integer $lastModified last modification timestamp
-     * @param float $changeFrequency change frequency. Use one of self:: constants here
+     * @param string $changeFrequency change frequency. Use one of self:: constants here
      * @param string $priority item's priority (0.0-1.0). Default null is equal to 0.5
      *
      * @throws \InvalidArgumentException


### PR DESCRIPTION
Parameter $changeFrequency expects one of the constants, which are defined as strings, but method's PhpDoc wrongly annotate it as float value