### PR TITLE
Fixes issue #17. Allow to set a file size limit

### DIFF
--- a/DeflateWriter.php
+++ b/DeflateWriter.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace samdark\sitemap;
+
+/**
+ * Flushes buffer into file with incremental deflating data, available in PHP 7.0+
+ */
+class DeflateWriter implements WriterInterface
+{
+    /**
+     * @var resource for target file
+     */
+    private $file;
+
+    /**
+     * @var resource for writable incremental deflate context
+     */
+    private $deflateContext;
+
+    /**
+     * @param string $filename target file
+     */
+    public function __construct($filename)
+    {
+        $this->file = fopen($filename, 'ab');
+        $this->deflateContext = deflate_init(ZLIB_ENCODING_GZIP);
+    }
+
+    /**
+     * Deflate data in a deflate context and write it to the target file
+     *
+     * @param string $data
+     * @param int $flushMode zlib flush mode to use for writing
+     */
+    private function write($data, $flushMode)
+    {
+        assert($this->file !== null);
+
+        $compressedChunk = deflate_add($this->deflateContext, $data, $flushMode);
+        fwrite($this->file, $compressedChunk);
+    }
+
+    /**
+     * Store data in a deflate stream
+     *
+     * @param string $data
+     */
+    public function append($data)
+    {
+        $this->write($data, ZLIB_NO_FLUSH);
+    }
+
+    /**
+     * Make sure all data was written
+     */
+    public function finish()
+    {
+        $this->write('', ZLIB_FINISH);
+
+        $this->file = null;
+        $this->deflateContext = null;
+    }
+}

--- a/PlainFileWriter.php
+++ b/PlainFileWriter.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace samdark\sitemap;
+
+/**
+ * Writes the given data as-is into a file
+ */
+class PlainFileWriter implements WriterInterface
+{
+    /**
+     * @var resource for target file
+     */
+    private $file;
+
+    /**
+     * @param string $filename target file
+     */
+    public function __construct($filename)
+    {
+        $this->file = fopen($filename, 'ab');
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function append($data)
+    {
+        assert($this->file !== null);
+
+        fwrite($this->file, $data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function finish()
+    {
+        assert($this->file !== null);
+
+        fclose($this->file);
+        $this->file = null;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Sitemap and sitemap index builder.
 Features
 --------
 
-- Create sitemap files.
+- Create sitemap files: either regular or gzipped.
 - Create multi-language sitemap files.
 - Create sitemap index files.
-- Automatically creates new file if 50000 URLs limit is reached.
-- Memory efficient buffer of configurable size.
+- Automatically creates new file if either URL limit or file size limit is reached.
+- Fast and memory efficient.
 
 Installation
 ------------

--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ There are methods to configure `Sitemap` instance:
 - `setMaxBytes($number)`. Sets maximum size of a single site map file.
   Default is 10MiB which should be compatible with most current search engines.
 - `setBufferSize($number)`. Sets number of URLs to be kept in memory before writing it to file.
-  Default is 1000. If you have more memory consider increasing it. If 1000 URLs doesn't fit,
-  decrease it.
+  Default is 10. Bigger values give marginal benefits.
+  On the other hand when the file size limit is hit, the complete buffer must be written to the next file.
 - `setUseIndent($bool)`. Sets if XML should be indented. Default is true.
 - `setUseGzip($bool)`. Sets whether the resulting sitemap files will be gzipped or not.
   Default is `false`. `zlib` extension must be enabled to use this feature.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ There are methods to configure `Sitemap` instance:
 - `setMaxUrls($number)`. Sets maximum number of URLs to write in a single file.
   Default is 50000 which is the limit according to specification and most of
   existing implementations.
+- `setMaxBytes($number)`. Sets maximum size of a single site map file.
+  Default is 10MiB which should be compatible with most current search engines.
 - `setBufferSize($number)`. Sets number of URLs to be kept in memory before writing it to file.
   Default is 1000. If you have more memory consider increasing it. If 1000 URLs doesn't fit,
   decrease it.

--- a/Sitemap.php
+++ b/Sitemap.php
@@ -56,7 +56,7 @@ class Sitemap
     /**
      * @var integer number of URLs to be kept in memory before writing it to file
      */
-    private $bufferSize = 1000;
+    private $bufferSize = 10;
 
     /**
      * @var bool if XML should be indented
@@ -266,10 +266,6 @@ class Sitemap
             $this->createNewFile();
         }
 
-        if ($this->urlsCount % $this->bufferSize === 0) {
-            $this->flush();
-        }
-
         if (is_array($location)) {
             $this->addMultiLanguageItem($location, $lastModified, $changeFrequency, $priority);
         } else {
@@ -277,6 +273,10 @@ class Sitemap
         }
 
         $this->urlsCount++;
+
+        if ($this->urlsCount % $this->bufferSize === 0) {
+            $this->flush();
+        }
     }
 
 
@@ -454,7 +454,7 @@ class Sitemap
 
     /**
      * Sets number of URLs to be kept in memory before writing it to file.
-     * Default is 1000.
+     * Default is 10.
      *
      * @param integer $number
      */

--- a/TempFileGZIPWriter.php
+++ b/TempFileGZIPWriter.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace samdark\sitemap;
+
+/**
+ * Flushes buffer into temporary stream and compresses stream into a file on finish
+ */
+class TempFileGZIPWriter implements WriterInterface
+{
+    /**
+     * @var string Name of target file
+     */
+    private $filename;
+
+    /**
+     * @var ressource for php://temp stream
+     */
+    private $tempFile;
+
+    /**
+     * @param string $filename target file
+     */
+    public function __construct($filename)
+    {
+        $this->filename = $filename;
+        $this->tempFile = fopen('php://temp/', 'wb');
+    }
+
+    /**
+     * Store data in a temporary stream/file
+     *
+     * @param string $data
+     */
+    public function append($data)
+    {
+        assert($this->tempFile !== null);
+
+        fwrite($this->tempFile, $data);
+    }
+
+    /**
+     * Deflate buffered data
+     */
+    public function finish()
+    {
+        assert($this->tempFile !== null);
+
+        $file = fopen('compress.zlib://' . $this->filename, 'wb');
+        rewind($this->tempFile);
+        stream_copy_to_stream($this->tempFile, $file);
+
+        fclose($file);
+        fclose($this->tempFile);
+        $this->tempFile = null;
+    }
+}

--- a/WriterInterface.php
+++ b/WriterInterface.php
@@ -1,0 +1,25 @@
+<?php
+namespace samdark\sitemap;
+
+/**
+ * WriterInterface represents a data sink
+ *
+ * Data is successively given by calling append. After calling finish all of it
+ * should have been written to the target.
+ */
+interface WriterInterface
+{
+    /**
+     * Queue data for writing to the target
+     *
+     * @param string $data
+     */
+    public function append($data);
+
+    /**
+     * Ensure all queued data is written and close the target
+     *
+     * No further data may be appended after this.
+     */
+    public function finish();
+}

--- a/tests/SitemapTest.php
+++ b/tests/SitemapTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace samdark\sitemap\tests;
 
+use SebastianBergmann\Timer\Timer;
+
 use samdark\sitemap\Sitemap;
 
 class SitemapTest extends \PHPUnit_Framework_TestCase
@@ -245,6 +247,7 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
         $sitemap = new Sitemap(__DIR__ . '/sitemap_multi.xml');
         $sizeLimit = 1036;
         $sitemap->setMaxBytes($sizeLimit);
+        $sitemap->setBufferSize(1);
 
         for ($i = 0; $i < 20; $i++) {
             $sitemap->addItem('http://example.com/mylink' . $i, time());
@@ -277,6 +280,7 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
         $fileName = __DIR__ . '/sitemap_regular.xml';
         $sitemap = new Sitemap($fileName);
         $sitemap->setMaxBytes(0);
+        $sitemap->setBufferSize(1);
 
         $exceptionCaught = false;
         try {
@@ -289,5 +293,33 @@ class SitemapTest extends \PHPUnit_Framework_TestCase
         unlink($fileName);
 
         $this->assertTrue($exceptionCaught, 'Expected OverflowException wasn\'t thrown.');
+    }
+
+    public function testBufferSizeImpact()
+    {
+        if (getenv('TRAVIS') == 'true') {
+            $this->markTestSkipped('Can not reliably test performance on travis-ci.');
+            return;
+        }
+
+        $fileName = __DIR__ . '/sitemap_big.xml';
+
+        $times = array();
+
+        foreach (array(1000, 10) as $bufferSize) {
+            $startTime = microtime(true);
+
+            $sitemap = new Sitemap($fileName);
+            $sitemap->setBufferSize($bufferSize);
+            for ($i = 0; $i < 50000; $i++) {
+                $sitemap->addItem('http://example.com/mylink' . $i, time());
+            }
+            $sitemap->write();
+
+            $times[] = microtime(true) - $startTime;
+            unlink($fileName);
+        }
+
+        $this->assertLessThan($times[0] * 1.2, $times[1]);
     }
 }


### PR DESCRIPTION
This adds a default file size limit of 10 MiB for all site map files.
Use `Sitemap::setMaxBytes` to set a custom value.

There were some changes necessary to make this feasible.
In particular I reduced the default buffer size to 10 and refactored the
file writing back ends into separate classes.
I also added some tests.

Update:
There was some weird 403 HTTP-Error in travis when accessing 
https://www.w3.org/2001/xml.xsd. I hope this goes away by itself.

Apart from that I have replaced the array short forms in the last commit
and slightly reduced the performance requirements in the timing test
from +10% to +20%. (Actual numbers in two tests where +11% and +14%,
all other where below +10%)