### PR TITLE
Add Example Stylesheet #79

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ $sitemap->addItem('http://example.com/mylink2', time());
 $sitemap->addItem('http://example.com/mylink3', time(), Sitemap::HOURLY);
 $sitemap->addItem('http://example.com/mylink4', time(), Sitemap::DAILY, 0.3);
 
+// set sitemap stylesheet (see example-sitemap-stylesheet.xsl)
+$sitemap->setStylesheet('http://example.com/css/sitemap.xsl');
+
 // write it
 $sitemap->write();
 
@@ -57,6 +60,9 @@ $staticSitemap->addItem('http://example.com/about');
 $staticSitemap->addItem('http://example.com/tos');
 $staticSitemap->addItem('http://example.com/jobs');
 
+// set optional stylesheet (see example-sitemap-stylesheet.xsl)
+$staticSitemap->setStylesheet('http://example.com/css/sitemap.xsl');
+
 // write it
 $staticSitemap->write();
 
@@ -66,7 +72,7 @@ $staticSitemapUrls = $staticSitemap->getSitemapUrls('http://example.com/');
 // create sitemap index file
 $index = new Index(__DIR__ . '/sitemap_index.xml');
 
-// set stylesheet
+// set index stylesheet (see example in repo)
 $index->setStylesheet('http://example.com/css/sitemap.xsl');
 
 // add URLs
@@ -114,6 +120,9 @@ $sitemap->addItem([
     'en' => 'http://example.com/en/mylink4',
 ], time(), Sitemap::DAILY, 0.3);
 
+// set stylesheet (see example-sitemap-stylesheet.xsl)
+$sitemap->setStylesheet('http://example.com/css/sitemap.xsl');
+
 // write it
 $sitemap->write();
 
@@ -135,13 +144,13 @@ There are methods to configure `Sitemap` instance:
 - `setUseIndent($bool)`. Sets if XML should be indented. Default is true.
 - `setUseGzip($bool)`. Sets whether the resulting sitemap files will be gzipped or not.
   Default is `false`. `zlib` extension must be enabled to use this feature.
-- `setStylesheet($string)`. Sets the `xml-stylesheet` tag. By default, tag is not generated. 
+- `setStylesheet($string)`. Sets the `xml-stylesheet` tag. By default, tag is not generated. See example [example-sitemap-stylesheet.xsl](/example-sitemap-stylesheet.xsl)  
 
 There is a method to configure `Index` instance:
 
 - `setUseGzip($bool)`. Sets whether the resulting index file will be gzipped or not.
   Default is `false`. `zlib` extension must be enabled to use this feature.
-- `setStylesheet($string)`. Sets the `xml-stylesheet` tag. By default, tag is not generated. 
+- `setStylesheet($string)`. Sets the `xml-stylesheet` tag. By default, tag is not generated. See example [example-sitemap-stylesheet.xsl](/example-sitemap-stylesheet.xsl) 
 
 Running tests
 -------------

--- a/example-sitemap-stylesheet.xsl
+++ b/example-sitemap-stylesheet.xsl
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8"?>
+	<xsl:stylesheet version="2.0"
+		xmlns:html="http://www.w3.org/TR/REC-html40"
+		xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+		xmlns:sitemap="http://www.sitemaps.org/schemas/sitemap/0.9"
+		xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:output method="html" version="1.0" encoding="UTF-8" indent="yes"/>
+	<xsl:template match="/">
+		<html xmlns="http://www.w3.org/1999/xhtml">
+		<head>
+			<title>XML Sitemap</title>
+			<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+			<style type="text/css">
+				body {
+					font-family: Helvetica, Arial, sans-serif;
+					font-size: 13px;
+					color: #545353;
+				}
+				table {
+					border: none;
+					border-collapse: collapse;
+				}
+				#sitemap tr:nth-child(odd) td {
+					background-color: #eee !important;
+				}
+				#sitemap tbody tr:hover td {
+					background-color: #ccc;
+				}
+				#sitemap tbody tr:hover td, #sitemap tbody tr:hover td a {
+					color: #000;
+				}
+				#content {
+					margin: 0 auto;
+					width: 1000px;
+				}
+				.expl {
+					margin: 18px 3px;
+					line-height: 1.2em;
+				}
+				.expl a {
+					color: #da3114;
+					font-weight: 600;
+				}
+				.expl a:visited {
+					color: #da3114;
+				}
+				a {
+					color: #000;
+					text-decoration: none;
+				}
+				a:visited {
+					color: #777;
+				}
+				a:hover {
+					text-decoration: underline;
+				}
+				td {
+					font-size:11px;
+				}
+				th {
+					text-align:left;
+					padding-right:30px;
+					font-size:11px;
+				}
+				thead th {
+					border-bottom: 1px solid #000;
+				}
+			</style>
+		</head>
+		<body>
+		<div id="content">
+			<h1>XML Sitemap</h1>
+			<p class="expl">
+				This is an XML Sitemap, meant for consumption by search engines.<br/>
+				You can find more information about XML sitemaps on <a href="http://sitemaps.org" target="_blank" rel="noopener noreferrer">sitemaps.org</a>.
+			</p>
+			<p class="expl">
+				This XML Sitemap has been generated using using the PHP package <a href="https://github.com/samdark/sitemap" target="_blank" rel="noopener noreferrer nofollow">samdark/sitemap</a>.<br/>
+				<img alt="Release Version" src="https://img.shields.io/github/v/release/samdark/sitemap?sort=semver&amp;style=flat-square"/>&#160;
+				<img alt="Tests" src="https://img.shields.io/github/workflow/status/samdark/sitemap/GitHub%20Action/master?label=tests&amp;style=flat-square"/>&#160;
+				<img alt="Packagist PHP Version Support" src="https://img.shields.io/packagist/php-v/samdark/sitemap?style=flat-square"/>&#160;
+			
+				<img alt="Monthly Downloads" src="https://img.shields.io/packagist/dm/samdark/sitemap?style=flat-square"/>&#160;
+				<img alt="Total Downloads" src="https://img.shields.io/packagist/dt/samdark/sitemap?style=flat-square&amp;label=total%20downloads"/>&#160;
+				<img alt="License" src="https://img.shields.io/github/license/samdark/sitemap?style=flat-square"/>&#160;
+			</p>
+			<hr/>
+			<xsl:if test="count(sitemap:sitemapindex/sitemap:sitemap) &gt; 0">
+				<p class="expl">
+					This XML Sitemap Index file contains <xsl:value-of select="count(sitemap:sitemapindex/sitemap:sitemap)"/> sitemaps.
+				</p>
+				<table id="sitemap" cellpadding="3">
+					<thead>
+					<tr>
+						<th width="75%">Sitemap</th>
+						<th width="25%">Last Modified</th>
+					</tr>
+					</thead>
+					<tbody>
+					<xsl:for-each select="sitemap:sitemapindex/sitemap:sitemap">
+						<xsl:variable name="sitemapURL">
+							<xsl:value-of select="sitemap:loc"/>
+						</xsl:variable>
+						<tr>
+							<td>
+								<a href="{$sitemapURL}"><xsl:value-of select="sitemap:loc"/></a>
+							</td>
+							<td>
+								<xsl:value-of select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)),concat(' ', substring(sitemap:lastmod,20,6)))"/>
+							</td>
+						</tr>
+					</xsl:for-each>
+					</tbody>
+				</table>
+			</xsl:if>
+			<xsl:if test="count(sitemap:sitemapindex/sitemap:sitemap) &lt; 1">
+				<p class="expl">
+					This XML Sitemap contains <xsl:value-of select="count(sitemap:urlset/sitemap:url)"/> URLs.
+				</p>
+				<table id="sitemap" cellpadding="3">
+					<thead>
+					<tr>
+						<th width="80%">URL</th>
+						<th width="5%">Images</th>
+						<th title="Last Modification Time" width="15%">Last Mod.</th>
+					</tr>
+					</thead>
+					<tbody>
+					<xsl:variable name="lower" select="'abcdefghijklmnopqrstuvwxyz'"/>
+					<xsl:variable name="upper" select="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'"/>
+					<xsl:for-each select="sitemap:urlset/sitemap:url">
+						<tr>
+							<td>
+								<xsl:variable name="itemURL">
+									<xsl:value-of select="sitemap:loc"/>
+								</xsl:variable>
+								<a href="{$itemURL}">
+									<xsl:value-of select="sitemap:loc"/>
+								</a>
+							</td>
+							<td>
+								<xsl:value-of select="count(image:image)"/>
+							</td>
+							<td>
+								<xsl:value-of select="concat(substring(sitemap:lastmod,0,11),concat(' ', substring(sitemap:lastmod,12,5)),concat(' ', substring(sitemap:lastmod,20,6)))"/>
+							</td>
+						</tr>
+					</xsl:for-each>
+					</tbody>
+				</table>
+			</xsl:if>
+		</div>
+		</body>
+		</html>
+	</xsl:template>
+	</xsl:stylesheet>
+


### PR DESCRIPTION
This adds the example XML Stylesheet which builds on work done in #63 
The sitemap works for Sitemap Index and Sitemap files which means the user can include just one file.

Closes #79 

### Example
This sheet has attribution and the badges to jazz it up a little.
![image](https://user-images.githubusercontent.com/774763/135702827-1059f338-c1f1-4b81-b2fa-38c622658751.png)
